### PR TITLE
Fix carousel display issues on mobile and desktop

### DIFF
--- a/components/PatentCarousel.vue
+++ b/components/PatentCarousel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="patent-carousel relative">
     <!-- Carousel container with full-width background -->
-    <div class="carousel-bg py-20 relative">
+    <div class="carousel-bg py-12 md:py-16 relative">
       <!-- Loading state -->
       <div v-if="isLoading" class="absolute inset-0 flex items-center justify-center bg-white bg-opacity-75 z-50">
         <div class="text-center">
@@ -13,22 +13,22 @@
       <!-- Navigation arrows - positioned with higher z-index to stay above slides -->
       <button 
         @click="prevSlide" 
-        class="absolute left-4 top-1/2 transform -translate-y-1/2 z-20 bg-dobbin-dark-green hover:bg-dobbin-green text-white p-3 rounded-full"
+        class="absolute left-2 md:left-4 top-1/2 transform -translate-y-1/2 z-20 bg-dobbin-dark-green hover:bg-dobbin-green text-white p-2 md:p-3 rounded-full"
         aria-label="Previous slide"
         v-if="hasValidPatents && allPatents.length > 1"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 md:h-6 md:w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
         </svg>
       </button>
       
       <button 
         @click="nextSlide" 
-        class="absolute right-4 top-1/2 transform -translate-y-1/2 z-20 bg-dobbin-dark-green hover:bg-dobbin-green text-white p-3 rounded-full"
+        class="absolute right-2 md:right-4 top-1/2 transform -translate-y-1/2 z-20 bg-dobbin-dark-green hover:bg-dobbin-green text-white p-2 md:p-3 rounded-full"
         aria-label="Next slide"
         v-if="hasValidPatents && allPatents.length > 1"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 md:h-6 md:w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
         </svg>
       </button>
@@ -63,12 +63,12 @@
       
       <!-- Carousel content aligned with text container -->
       <div v-if="!isLoading && hasValidPatents" class="container mx-auto px-4">
-        <!-- Removed max-width to match paragraph width -->
-        <div class="mx-auto"> 
+        <!-- Constrained width container -->
+        <div class="mx-auto max-w-4xl"> 
           <!-- Carousel slide container -->
-          <div class="slide-container bg-white shadow-lg rounded overflow-hidden">
-            <!-- Slide container -->
-            <div class="relative">
+          <div class="slide-container bg-white shadow-lg rounded-lg overflow-hidden">
+            <!-- Slide container with proper sizing -->
+            <div class="relative w-full carousel-slides-wrapper">
               <PatentSlide 
                 v-for="(patent, idx) in allPatents" 
                 :key="'patent-' + idx" 
@@ -228,12 +228,9 @@ onUnmounted(() => {
   background-repeat: no-repeat;
   background-color: #e5ede8; /* Light green color as fallback and overlay tint */
   background-blend-mode: overlay; /* Blend the image with the background color */
-  width: 100vw;
-  position: relative;
-  left: 50%;
-  right: 50%;
-  margin-left: -50vw;
-  margin-right: -50vw;
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden; /* Prevent horizontal overflow */
 }
 
 /* Ensure the background has a green tint */
@@ -248,21 +245,47 @@ onUnmounted(() => {
   z-index: -1;
 }
 
-/* Fixed height container for slides to prevent layout shifts */
+/* Responsive slide container */
 .slide-container {
   position: relative;
-  min-height: 550px;
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  box-sizing: border-box;
+  overflow: hidden; /* Prevent horizontal overflow */
 }
 
-/* Animations disabled */
-.slide-enter-active,
-.slide-leave-active,
-.slide-enter-from,
-.slide-leave-to {
-  transition: none;
-  position: absolute;
+/* Wrapper for slides with height management */
+.carousel-slides-wrapper {
+  position: relative;
   width: 100%;
-  transform: none;
-  opacity: 1;
+  height: auto;
+  min-height: 300px; /* Minimum height to maintain consistency */
+}
+
+/* Add media queries for better mobile/desktop handling */
+@media (max-width: 768px) {
+  .carousel-bg {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+  
+  .carousel-slides-wrapper {
+    min-height: auto; /* Let content determine height on mobile */
+  }
+}
+
+@media (min-width: 769px) and (max-width: 1023px) {
+  /* Tablet adjustments */
+  .carousel-slides-wrapper {
+    min-height: 400px;
+  }
+}
+
+@media (min-width: 1024px) {
+  /* Desktop adjustments */
+  .carousel-slides-wrapper {
+    min-height: 450px;
+  }
 }
 </style>

--- a/components/PatentSlide.vue
+++ b/components/PatentSlide.vue
@@ -6,12 +6,12 @@
     <!-- Added patent existence check -->
     <template v-if="patent">
       <!-- Slide image with white background -->
-      <div class="md:w-1/2 p-10 bg-white">
+      <div class="md:w-1/2 p-6 md:p-10 bg-white">
         <img 
           v-if="currentImageSrc && !imageLoadError"
           :src="currentImageSrc" 
           :alt="patent.title" 
-          class="max-w-full max-h-96 object-contain patent-image mx-auto"
+          class="max-w-full max-h-64 md:max-h-80 object-contain patent-image mx-auto"
           @error="handleImageError"
         />
         <div v-else class="flex items-center justify-center h-full">
@@ -26,9 +26,9 @@
       </div>
       
       <!-- Slide content -->
-      <div class="md:w-1/2 p-10 bg-white">
-        <h3 class="text-2xl font-bold mb-6 text-dobbin-dark-green patent-title">{{ patent.title }}</h3>
-        <p class="mb-8 text-gray-700 patent-description">{{ patent.description }}</p>
+      <div class="md:w-1/2 p-6 md:p-10 bg-white">
+        <h3 class="text-xl md:text-2xl font-bold mb-4 md:mb-6 text-dobbin-dark-green patent-title">{{ patent.title }}</h3>
+        <p class="mb-6 md:mb-8 text-sm md:text-base text-gray-700 patent-description">{{ patent.description }}</p>
         <a 
           :href="getGooglePatentUrl(patent.patentNumber)"
           class="inline-block bg-dobbin-green hover:bg-dobbin-dark-green text-white font-bold py-2 px-6 patent-button"
@@ -239,24 +239,29 @@ onMounted(() => {
 <style scoped>
 /* Ensure slide has proper positioning for animation */
 .patent-slide {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 100%;
+  position: relative; /* Changed from absolute to relative */
+  width: 100%;
+  box-sizing: border-box;
+  height: auto; /* Auto height instead of 100% */
+  min-height: 300px; /* Minimum height to avoid layout shifts */
 }
 
-/* Animation for individual elements - disabled for now */
-.patent-image, .patent-title, .patent-description, .patent-button {
-  transition: none; /* Disabled transitions */
-}
-
-/* Additional centering and sizing for image */
+/* Responsive image sizing */
 .patent-image {
   display: block;
   margin: 0 auto;
-  max-height: 350px;
+  max-height: 250px;
   width: auto;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .patent-slide {
+    min-height: auto; /* Allow content to determine height on mobile */
+  }
+  
+  .patent-image {
+    max-height: 180px; /* Smaller image on mobile */
+  }
 }
 </style>


### PR DESCRIPTION
- Fix vertical overflow on mobile by setting patent-slide to position: relative
- Add responsive sizing for carousel slides and images 
- Add proper responsive padding and text sizing
- Fix horizontal overflow by adding overflow: hidden to containers
- Adjust mobile spacing and container dimensions
- Optimize slide wrapper min-height for different screen sizes